### PR TITLE
Increase meteor damage and heal amount

### DIFF
--- a/game.js
+++ b/game.js
@@ -244,7 +244,7 @@ function triggerSpecial(type,x,y){
 
   if(type === "meteor"){
     for(const e of enemyUnits){
-      if(Math.hypot(e.x - x, e.y - y) <= radius){ e.hp -= 50; }
+      if(Math.hypot(e.x - x, e.y - y) <= radius){ e.hp -= 200; }
     }
     mana.meteor = 0;
     specialEffects.push(new SpecialCircle(x,y,"red"));
@@ -253,7 +253,7 @@ function triggerSpecial(type,x,y){
 
   if(type === "heal"){
     for(const p of playerUnits){
-      if(Math.hypot(p.x - x, p.y - y) <= radius){ p.hp += 30; }
+      if(Math.hypot(p.x - x, p.y - y) <= radius){ p.hp += 100; }
     }
     mana.heal = 0;
     specialEffects.push(new SpecialCircle(x,y,"green"));


### PR DESCRIPTION
## Summary
- Amplify Meteor special to deal 200 damage to enemies within range
- Boost Healing special to restore 100 HP to allied units in range

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc00463590833398a66ae4e94417b9