### PR TITLE
Enhance special effects with repeated pulses and captions

### DIFF
--- a/game.js
+++ b/game.js
@@ -239,6 +239,7 @@ function triggerSpecial(type,x,y){
     },5000);
     mana.freeze = 0;
     specialEffects.push(new SpecialCircle(x,y,"gray"));
+    specialEffects.push(new SpecialText("❄️ フリーズ！！"));
     updateManaUI("freeze");
   }
 
@@ -248,6 +249,7 @@ function triggerSpecial(type,x,y){
     }
     mana.meteor = 0;
     specialEffects.push(new SpecialCircle(x,y,"red"));
+    specialEffects.push(new SpecialText("☄️ メテオ！！"));
     updateManaUI("meteor");
   }
 
@@ -257,6 +259,7 @@ function triggerSpecial(type,x,y){
     }
     mana.heal = 0;
     specialEffects.push(new SpecialCircle(x,y,"green"));
+    specialEffects.push(new SpecialText("✨ ヒーリング！！"));
     updateManaUI("heal");
   }
 }

--- a/projectiles.js
+++ b/projectiles.js
@@ -32,7 +32,37 @@ class SwingMark{ constructor(x,y,side){ this.x=x; this.y=y; this.life=12; this.s
 
 // 特殊攻撃の範囲エフェクト
 class SpecialCircle{
-  constructor(x,y,color){ this.x=x; this.y=y; this.color=color; this.radius=0; this.active=true; }
-  update(){ this.radius += 8; if(this.radius > 140) this.active=false; }
-  draw(){ ctx.strokeStyle=this.color; ctx.beginPath(); ctx.arc(this.x,this.y,this.radius,0,Math.PI*2); ctx.stroke(); }
+  constructor(x,y,color){
+    this.x=x; this.y=y; this.color=color;
+    this.radius=0; this.active=true; this.count=0;
+  }
+  update(){
+    this.radius += 8;
+    if(this.radius > 140){
+      this.count++;
+      if(this.count>=3) this.active=false;
+      else this.radius=0;
+    }
+  }
+  draw(){
+    ctx.strokeStyle=this.color;
+    ctx.beginPath();
+    ctx.arc(this.x,this.y,this.radius,0,Math.PI*2);
+    ctx.stroke();
+  }
+}
+
+// 特殊攻撃の字幕表示
+class SpecialText{
+  constructor(text){ this.text=text; this.life=60; this.active=true; }
+  update(){ this.life--; if(this.life<=0) this.active=false; }
+  draw(){
+    ctx.save();
+    ctx.fillStyle="white";
+    ctx.font="40px sans-serif";
+    ctx.textAlign="center";
+    ctx.globalAlpha = this.life/60;
+    ctx.fillText(this.text, canvas.width/2, canvas.height/2);
+    ctx.restore();
+  }
 }


### PR DESCRIPTION
## Summary
- Repeat special ability circle effect three times for a more impactful visual.
- Show center-screen captions for Freeze, Meteor, and Heal specials.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68bc030931f483339332c26b13c8c04d