### PR TITLE
Thicken special attack circle lines

### DIFF
--- a/projectiles.js
+++ b/projectiles.js
@@ -45,10 +45,13 @@ class SpecialCircle{
     }
   }
   draw(){
+    ctx.save();
     ctx.strokeStyle=this.color;
+    ctx.lineWidth = 20;
     ctx.beginPath();
     ctx.arc(this.x,this.y,this.radius,0,Math.PI*2);
     ctx.stroke();
+    ctx.restore();
   }
 }
 


### PR DESCRIPTION
## Summary
- Make special attack concentric circle lines significantly thicker

## Testing
- `node --check projectiles.js`

------
https://chatgpt.com/codex/tasks/task_e_68bc055242bc83339de63c71d3397ee1