### PR TITLE
Award bonus gold for surviving units on victory

### DIFF
--- a/game.js
+++ b/game.js
@@ -257,7 +257,13 @@ updateManaUI("heal");
 
   
   if(playerBaseHP<=0){ endScreen("GAME OVER","red"); return; }
-  if(enemyBaseHP<=0){ endScreen("VICTORY!","yellow"); return; }
+  if(enemyBaseHP<=0){
+    const remaining = playerUnits.filter(u => u.hp > 0).length;
+    playerGold += remaining * 150;
+    updateGoldUI();
+    endScreen("VICTORY!","yellow");
+    return;
+  }
 
   requestAnimationFrame(loop);
 }


### PR DESCRIPTION
## Summary
- Grant bonus gold for each surviving player unit when the enemy base falls
- Refresh gold display before showing the victory screen

## Testing
- `node --check game.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc10ff93ac8333991b1739116ca1bf