### PR TITLE
Use data-unit attributes for spawn buttons

### DIFF
--- a/game.js
+++ b/game.js
@@ -35,6 +35,11 @@ const unitCosts = {
   archer: 150,
   healer: 120
 };
+const unitNames = {
+  swordsman: "ナイト",
+  archer: "アーチャー",
+  healer: "クレリック"
+};
 const enemyBounties = {
   goblin: 20,
   orc: 40,
@@ -120,13 +125,11 @@ function updateManaUI(type){
 function updateGoldUI(){
   const display = document.getElementById("goldDisplay");
   if(display) display.textContent = `Gold: ${playerGold}`;
-  const buttons = document.querySelectorAll('#ui button');
+  const buttons = document.querySelectorAll('#ui .unit-btn');
   buttons.forEach(btn => {
-    const match = btn.getAttribute('onclick')?.match(/'([^']+)'/);
-    if(match){
-      const type = match[1];
-      btn.disabled = playerGold < unitCosts[type];
-    }
+    const type = btn.dataset.unit;
+    btn.textContent = `${unitNames[type]}召喚 (${unitCosts[type]}G)`;
+    btn.disabled = playerGold < unitCosts[type];
   });
 }
 

--- a/index.html
+++ b/index.html
@@ -72,9 +72,9 @@
 
 <div id="ui">
   <div id="goldDisplay">Gold: 500</div>
-  <button onclick="chooseUnit('swordsman')">ナイト召喚</button>
-  <button onclick="chooseUnit('archer')">アーチャー召喚</button>
-  <button onclick="chooseUnit('healer')">クレリック召喚</button>
+  <button class="unit-btn" data-unit="swordsman" onclick="chooseUnit('swordsman')">ナイト召喚</button>
+  <button class="unit-btn" data-unit="archer" onclick="chooseUnit('archer')">アーチャー召喚</button>
+  <button class="unit-btn" data-unit="healer" onclick="chooseUnit('healer')">クレリック召喚</button>
 </div>
 
 <!-- スペシャル攻撃 UI -->


### PR DESCRIPTION
## Summary
- Add `unitNames` mapping and update gold UI to label summon buttons dynamically
- Tag summon buttons with `data-unit` for cleaner lookup

## Testing
- `node --check game.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc131953dc8333949bc074cf35c0c3