### PR TITLE
Add pressed state and styles for unit selection buttons

### DIFF
--- a/game.js
+++ b/game.js
@@ -3,6 +3,11 @@
 // =====================
 const canvas = document.getElementById("gameCanvas");
 const ctx = canvas.getContext("2d");
+document.querySelectorAll('.unit-btn').forEach(btn => {
+  btn.addEventListener('mousedown', () => btn.classList.add('pressed'));
+  btn.addEventListener('mouseup', () => btn.classList.remove('pressed'));
+  btn.addEventListener('mouseleave', () => btn.classList.remove('pressed'));
+});
 let playerBaseHP, enemyBaseHP, playerUnits, enemyUnits, projectiles, hitMarks, swingMarks, specialEffects;
 let pendingUnitType = null;
 let pendingSpecial = null;

--- a/index.html
+++ b/index.html
@@ -13,6 +13,24 @@
   input[type=range] { width:230px; }
   #ui { margin-top:10px; display:none; }
   #ui button { margin:5px; padding:8px 16px; font-size:14px; }
+  .unit-btn {
+    margin:5px;
+    padding:8px 16px;
+    font-size:14px;
+    color:#eee;
+    background:linear-gradient(#555, #333);
+    border:1px solid #666;
+    cursor:pointer;
+    transition:background 0.3s, transform 0.05s;
+  }
+  .unit-btn:hover {
+    background:linear-gradient(#666, #444);
+  }
+  .unit-btn:active,
+  .unit-btn.pressed {
+    background:linear-gradient(#333, #111);
+    transform:translateY(2px);
+  }
   #help, #settings { display:none; text-align:left; max-width:700px; margin:20px auto; padding:12px; background:#111; border:1px solid #555; }
   @keyframes manaBlink {
     0%, 100% { filter: drop-shadow(0 0 2px gold); opacity:1; }


### PR DESCRIPTION
## Summary
- style unit selection buttons with gradient backgrounds and pressed transform
- add JS listeners to toggle `.pressed` class on button interactions

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc1774d6e883339a634d5b3afb8639