### PR TITLE
Add game speed toggle button

### DIFF
--- a/game.js
+++ b/game.js
@@ -55,16 +55,33 @@ const enemyBounties = {
   dragon: 500
 };
 
+const speedLevels = [1,1.5,2];
+let speedIndex = 0;
+let gameSpeed = speedLevels[speedIndex];
+
+function toggleSpeed(){
+  speedIndex = (speedIndex + 1) % speedLevels.length;
+  gameSpeed = speedLevels[speedIndex];
+  const btn = document.getElementById("speedBtn");
+  if(btn) btn.textContent = `x${gameSpeed}`;
+}
+
 function startGame(){
   document.getElementById("menu").style.display="none";
   document.getElementById("settings").style.display="none";
   document.getElementById("help").style.display="none";
   document.getElementById("title").style.display="none";
+  document.getElementById("gameArea").style.display="block";
   canvas.style.display="block";
   document.getElementById("ui").style.display="block";
 
     // ✅ ここを追加
   document.getElementById("specialUI").style.display = "block";
+
+  speedIndex = 0;
+  gameSpeed = speedLevels[speedIndex];
+  const sb = document.getElementById("speedBtn");
+  if(sb) sb.textContent = `x${gameSpeed}`;
 
   playerBaseHP=100; enemyBaseHP=100;
   playerUnits=[]; enemyUnits=[]; projectiles=[]; hitMarks=[]; swingMarks=[]; specialEffects=[];
@@ -228,7 +245,7 @@ function loop(){
     }
   }
 
-  for(const u of [...playerUnits,...enemyUnits]) if(u.cooldown>0) u.cooldown--;
+  for(const u of [...playerUnits,...enemyUnits]) if(u.cooldown>0) u.cooldown = Math.max(0, u.cooldown - gameSpeed);
 
   for(const pr of projectiles){ pr.update(); pr.draw(); }
   projectiles = projectiles.filter(pr=>pr.active);
@@ -255,9 +272,9 @@ function loop(){
   playerUnits = playerUnits.filter(u=>u.hp>0 && u.y>0);
 
 // === マナ自動回復 ===
-mana.freeze = Math.min(maxMana.freeze, mana.freeze + 0.167);  // 10秒でMAX
-mana.meteor = Math.min(maxMana.meteor, mana.meteor + 0.0625); // 40秒でMAX
-mana.heal   = Math.min(maxMana.heal,   mana.heal   + 0.1);    // 20秒でMAX
+mana.freeze = Math.min(maxMana.freeze, mana.freeze + 0.167 * gameSpeed);  // 10秒でMAX
+mana.meteor = Math.min(maxMana.meteor, mana.meteor + 0.0625 * gameSpeed); // 40秒でMAX
+mana.heal   = Math.min(maxMana.heal,   mana.heal   + 0.1 * gameSpeed);    // 20秒でMAX
 
 updateManaUI("freeze");
 updateManaUI("meteor");
@@ -346,3 +363,4 @@ window.showHelp = showHelp;
 window.backToMenuFromHelp = backToMenuFromHelp;
 window.chooseUnit = chooseUnit;
 window.useSpecial = useSpecial;
+window.toggleSpeed = toggleSpeed;

--- a/index.html
+++ b/index.html
@@ -7,6 +7,8 @@
 <style>
   body { margin:0; background:#222; color:#eee; font-family:monospace; text-align:center; }
   #gameCanvas { background:#333; display:none; margin:0 auto; border:2px solid #000; }
+  #gameArea { position:relative; width:400px; margin:0 auto; display:none; }
+  #speedBtn { position:absolute; top:10px; right:10px; padding:4px 8px; }
   #menu, #settings, #help { margin-top:20px; }
   h1 { margin:20px; }
   .unit-settings { border:1px solid #555; padding:10px; margin:10px auto; width:90%; max-width:420px; text-align:left; }
@@ -86,7 +88,10 @@
   <button onclick="backToMenuFromHelp()">戻る</button>
 </div>
 
-<canvas id="gameCanvas" width="400" height="600"></canvas>
+<div id="gameArea">
+  <canvas id="gameCanvas" width="400" height="600"></canvas>
+  <button id="speedBtn" onclick="toggleSpeed()">x1</button>
+</div>
 
 <div id="ui">
   <div id="goldDisplay">Gold: 500</div>

--- a/projectiles.js
+++ b/projectiles.js
@@ -5,7 +5,7 @@ class Projectile{
     const dx=this.target.x-this.x, dy=this.target.y-this.y;
     const d=Math.hypot(dx,dy);
     if(d<5){ this.target.hp-=this.atk; hitMarks.push(new HitMark(this.target.x,this.target.y)); this.active=false; }
-    else { this.x += (dx/d)*this.speed; this.y += (dy/d)*this.speed; }
+    else { this.x += (dx/d)*this.speed*gameSpeed; this.y += (dy/d)*this.speed*gameSpeed; }
   }
   draw(){ ctx.fillStyle=this.color; ctx.beginPath(); ctx.arc(this.x,this.y,4,0,Math.PI*2); ctx.fill(); }
 }
@@ -16,16 +16,16 @@ class HealProjectile{
     const dx=this.target.x-this.x, dy=this.target.y-this.y;
     const d=Math.hypot(dx,dy);
     if(d<5){ this.target.hp += this.amount; hitMarks.push(new HealMark(this.target.x,this.target.y)); this.active=false; }
-    else { this.x += (dx/d)*this.speed; this.y += (dy/d)*this.speed; }
+    else { this.x += (dx/d)*this.speed*gameSpeed; this.y += (dy/d)*this.speed*gameSpeed; }
   }
   draw(){ ctx.fillStyle="lime"; ctx.beginPath(); ctx.arc(this.x,this.y,4,0,Math.PI*2); ctx.fill(); }
 }
-class HitMark{ constructor(x,y){ this.x=x; this.y=y; this.life=15; } update(){ this.life--; }
+class HitMark{ constructor(x,y){ this.x=x; this.y=y; this.life=15; } update(){ this.life-=gameSpeed; }
   draw(){ ctx.lineWidth=3; ctx.strokeStyle="red"; ctx.beginPath(); ctx.moveTo(this.x-8,this.y-8); ctx.lineTo(this.x+8,this.y+8);
          ctx.moveTo(this.x+8,this.y-8); ctx.lineTo(this.x-8,this.y+8); ctx.stroke(); ctx.lineWidth=1; } }
-class HealMark{ constructor(x,y){ this.x=x; this.y=y; this.life=15; } update(){ this.life--; }
+class HealMark{ constructor(x,y){ this.x=x; this.y=y; this.life=15; } update(){ this.life-=gameSpeed; }
   draw(){ ctx.strokeStyle="lime"; ctx.lineWidth=3; ctx.beginPath(); ctx.arc(this.x,this.y,14,0,Math.PI*2); ctx.stroke(); ctx.lineWidth=1; } }
-class SwingMark{ constructor(x,y,side){ this.x=x; this.y=y; this.life=12; this.side=side; } update(){ this.life--; }
+class SwingMark{ constructor(x,y,side){ this.x=x; this.y=y; this.life=12; this.side=side; } update(){ this.life-=gameSpeed; }
   draw(){ ctx.save(); ctx.lineWidth=3; ctx.strokeStyle=(this.side==="player")?"#88f":"#f88";
          ctx.beginPath(); ctx.arc(this.x,this.y,16,-Math.PI/3,0); ctx.stroke();
          ctx.beginPath(); ctx.arc(this.x,this.y,12,0,Math.PI/3); ctx.stroke(); ctx.restore(); } }
@@ -39,7 +39,7 @@ class SpecialCircle{
     this.radius=0; this.active=true; this.count=0;
   }
   update(){
-    this.radius += 8;
+    this.radius += 8*gameSpeed;
     if(this.radius > 140){
       this.count++;
       if(this.count>=3) this.active=false;
@@ -60,7 +60,7 @@ class SpecialCircle{
 // 特殊攻撃の字幕表示
 class SpecialText{
   constructor(text){ this.text=text; this.life=60; this.active=true; }
-  update(){ this.life--; if(this.life<=0) this.active=false; }
+  update(){ this.life-=gameSpeed; if(this.life<=0) this.active=false; }
   draw(){
     ctx.save();
     ctx.fillStyle="white";

--- a/units.js
+++ b/units.js
@@ -77,7 +77,7 @@ class Unit {
       }
     }
 
-    this.y += (this.side==="player" ? -this.speed : this.speed);
+    this.y += (this.side==="player" ? -this.speed : this.speed) * gameSpeed;
   }
 }
 


### PR DESCRIPTION
## Summary
- Add speed toggle button to game UI and supporting styles
- Implement game speed cycling between 1x, 1.5x, and 2x
- Scale unit, projectile, and effect updates by current game speed

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc18ebe0588333b845dcffafbe77f3