### PR TITLE
Fix canvas initialization timing

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,8 +1,8 @@
 // =====================
 // ゲーム進行制御
 // =====================
-const canvas = document.getElementById("gameCanvas");
-const ctx = canvas.getContext("2d");
+let canvas;
+let ctx;
 document.querySelectorAll('.unit-btn').forEach(btn => {
   btn.addEventListener('mousedown', () => btn.classList.add('pressed'));
   btn.addEventListener('mouseup', () => btn.classList.remove('pressed'));
@@ -67,6 +67,9 @@ function toggleSpeed(){
 }
 
 function startGame(){
+  canvas = document.getElementById("gameCanvas");
+  ctx = canvas.getContext("2d");
+
   document.getElementById("menu").style.display="none";
   document.getElementById("settings").style.display="none";
   document.getElementById("help").style.display="none";


### PR DESCRIPTION
## Summary
- Initialize `canvas` and `ctx` when the game starts rather than at script load
- Ensure game loop and related functions reference the newly initialized canvas context

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1cafa284833394e392b44a15dac1