### PR TITLE
Add fireball projectile and apply to dragon attacks

### DIFF
--- a/game.js
+++ b/game.js
@@ -199,7 +199,7 @@ function loop(){
           p.cooldown=120;  // ★ 60 → 120
         }
         if(p.role==="dragon" && inUnitRange(p,e) && p.cooldown<=0){
-          projectiles.push(new Projectile(p.x,p.y-12,e,p.atk,"orange"));
+          projectiles.push(new Projectile(p.x,p.y-12,e,p.atk,{shape:"fireball", color:"orange", size:10}));
           p.cooldown=150;
         }
       }
@@ -244,7 +244,7 @@ function loop(){
       if(e.role==="dragon" && e.cooldown<=0 && playerUnits.length>0){
         const t=playerUnits[Math.floor(Math.random()*playerUnits.length)];
         if(inUnitRange(e,t)){
-          projectiles.push(new Projectile(e.x,e.y+12,t,e.atk,"orange"));
+          projectiles.push(new Projectile(e.x,e.y+12,t,e.atk,{shape:"fireball", color:"orange", size:10}));
           e.cooldown=150;
         }
       }

--- a/projectiles.js
+++ b/projectiles.js
@@ -1,5 +1,5 @@
 class Projectile{
-  constructor(x,y,target,atk,color="white"){ this.x=x; this.y=y; this.target=target; this.atk=atk; this.speed=3; this.active=true; this.color=color; }
+  constructor(x,y,target,atk,opts="white"){ this.x=x; this.y=y; this.target=target; this.atk=atk; this.speed=3; this.active=true; if(typeof opts==="string"){ this.color=opts; this.size=4; this.shape=null; } else { this.color=opts.color||"white"; this.size=opts.size||4; this.shape=opts.shape||null; } }
   update(){
     if(!this.target || this.target.hp<=0){ this.active=false; return; }
     const dx=this.target.x-this.x, dy=this.target.y-this.y;
@@ -7,7 +7,7 @@ class Projectile{
     if(d<5){ this.target.hp-=this.atk; hitMarks.push(new HitMark(this.target.x,this.target.y)); this.active=false; }
     else { this.x += (dx/d)*this.speed*gameSpeed; this.y += (dy/d)*this.speed*gameSpeed; }
   }
-  draw(){ ctx.fillStyle=this.color; ctx.beginPath(); ctx.arc(this.x,this.y,4,0,Math.PI*2); ctx.fill(); }
+  draw(){ if(this.shape==="fireball"){ const g=ctx.createRadialGradient(this.x,this.y,0,this.x,this.y,this.size); g.addColorStop(0,"orange"); g.addColorStop(1,"red"); ctx.fillStyle=g; ctx.beginPath(); ctx.arc(this.x,this.y,this.size,0,Math.PI*2); ctx.fill(); } else { ctx.fillStyle=this.color; ctx.beginPath(); ctx.arc(this.x,this.y,this.size,0,Math.PI*2); ctx.fill(); } }
 }
 class HealProjectile{
   constructor(x,y,target,amount){ this.x=x; this.y=y; this.target=target; this.amount=amount; this.speed=3; this.active=true; }


### PR DESCRIPTION
## Summary
- Support configurable projectile shapes with new fireball gradient effect
- Use fireball projectiles for both player and enemy dragon attacks

## Testing
- `npm test` *(fails: ENOENT, no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3e57698883339f2dc9e03e1db492