### PR TITLE
Add pressed style behavior for unit buttons

### DIFF
--- a/game.js
+++ b/game.js
@@ -3,7 +3,12 @@
 // =====================
 let canvas;
 let ctx;
-document.querySelectorAll('.unit-btn, .special-btn').forEach(btn => {
+document.querySelectorAll('.unit-btn').forEach(btn => {
+  btn.addEventListener('mousedown', () => btn.classList.add('pressed'));
+  btn.addEventListener('mouseup', () => btn.classList.remove('pressed'));
+  btn.addEventListener('mouseleave', () => btn.classList.remove('pressed'));
+});
+document.querySelectorAll('.special-btn').forEach(btn => {
   btn.addEventListener('mousedown', () => btn.classList.add('pressed'));
   btn.addEventListener('mouseup', () => btn.classList.remove('pressed'));
   btn.addEventListener('mouseleave', () => btn.classList.remove('pressed'));


### PR DESCRIPTION
## Summary
- define gradient-based `.unit-btn` styles and apply to unit selection buttons
- add JS listeners to apply a `.pressed` class on mousedown and remove on mouseup/leave for unit and special buttons

## Testing
- `node --check game.js`


------
https://chatgpt.com/codex/tasks/task_e_68bc47a3df1c8333bd0318116eeaf05f