### PR TITLE
feat: add fireball projectile option

### DIFF
--- a/game.js
+++ b/game.js
@@ -205,10 +205,10 @@ function loop(){
             p.cooldown=120;  // ★ 60 → 120
           }
 
-        if(p.role==="dragon" && inUnitRange(p,e) && p.cooldown<=0){
-          projectiles.push(new Projectile(p.x,p.y-12,e,p.atk,{color:"orange"}));
-          p.cooldown=150;
-        }
+          if(p.role==="dragon" && inUnitRange(p,e) && p.cooldown<=0){
+            projectiles.push(new Projectile(p.x,p.y-12,e,p.atk,{shape:"fireball", color:"orange", size:10}));
+            p.cooldown=150;
+          }
       }
     }
     if(p.role==="healer" && p.cooldown<=0){
@@ -250,13 +250,13 @@ function loop(){
           e.cooldown=200;  // ★ 100 → 200
         }
       }
-      if(e.role==="dragon" && e.cooldown<=0 && playerUnits.length>0){
-        const t=playerUnits[Math.floor(Math.random()*playerUnits.length)];
-        if(inUnitRange(e,t)){
-          projectiles.push(new Projectile(e.x,e.y+12,t,e.atk,"orange"));
-          e.cooldown=150;
+        if(e.role==="dragon" && e.cooldown<=0 && playerUnits.length>0){
+          const t=playerUnits[Math.floor(Math.random()*playerUnits.length)];
+          if(inUnitRange(e,t)){
+            projectiles.push(new Projectile(e.x,e.y+12,t,e.atk,{shape:"fireball", color:"orange", size:10}));
+            e.cooldown=150;
+          }
         }
-      }
     }
   }
 

--- a/projectiles.js
+++ b/projectiles.js
@@ -35,6 +35,16 @@ class Projectile{
       ctx.closePath();
       ctx.fill();
       ctx.restore();
+    }else if(this.shape==="fireball"){
+      ctx.save();
+      const g = ctx.createRadialGradient(this.x,this.y,0,this.x,this.y,this.size);
+      g.addColorStop(0,"orange");
+      g.addColorStop(1,"red");
+      ctx.fillStyle = g;
+      ctx.beginPath();
+      ctx.arc(this.x,this.y,this.size,0,Math.PI*2);
+      ctx.fill();
+      ctx.restore();
     }else{
       ctx.beginPath();
       ctx.arc(this.x,this.y,this.size,0,Math.PI*2);


### PR DESCRIPTION
## Summary
- add fireball projectile type rendering with orange to red gradient
- give dragons fireball projectiles with larger size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd197784a48333aa76ef5e5556b4cf