### PR TITLE
Expand dragon to span three lanes

### DIFF
--- a/game.js
+++ b/game.js
@@ -22,6 +22,10 @@ let enemySpawnTimer = null;
 function inMeleeRange(a,b){
   const laneDiff = Math.abs(a.lane-b.lane);
   const dy = Math.abs(a.y-b.y);
+  if(a.role==="dragon" || b.role==="dragon"){
+    if(laneDiff<=1) return dy<=24;
+    return false;
+  }
   if(laneDiff===0) return dy<=24;
   if(laneDiff===1) return dy<=20;
   return false;
@@ -29,8 +33,16 @@ function inMeleeRange(a,b){
 
 // 射程判定
 function inUnitRange(a,b){
-  const dx = (a.lane-b.lane)*(canvas.width/5);
+  let laneDiff = a.lane-b.lane;
+  let dx = laneDiff*(canvas.width/5);
   const dy = (a.y-b.y);
+  if(a.role==="dragon" || b.role==="dragon"){
+    if(Math.abs(laneDiff)<=1){
+      dx = 0;
+    }else{
+      dx = (Math.abs(laneDiff)-1)*(canvas.width/5)*Math.sign(laneDiff);
+    }
+  }
   return Math.hypot(dx,dy) <= a.range;
 }
 

--- a/units.js
+++ b/units.js
@@ -52,11 +52,21 @@ class Unit {
   }
 
   draw(){
-    ctx.fillStyle=this.color;
-    ctx.beginPath(); ctx.arc(this.x,this.y,12,0,Math.PI*2); ctx.fill();
-    ctx.fillStyle=(this.side==="player")?"white":"black";
-    ctx.font="14px sans-serif"; ctx.textAlign="center"; ctx.textBaseline="middle";
-    ctx.fillText(this.label,this.x,this.y);
+    if(this.role==="dragon"){
+      const width = canvas.width * 3/5;
+      const height = 60;
+      ctx.fillStyle=this.color;
+      ctx.fillRect(this.x - width/2, this.y - height/2, width, height);
+      ctx.fillStyle=(this.side==="player")?"white":"black";
+      ctx.font="24px sans-serif"; ctx.textAlign="center"; ctx.textBaseline="middle";
+      ctx.fillText(this.label,this.x,this.y);
+    }else{
+      ctx.fillStyle=this.color;
+      ctx.beginPath(); ctx.arc(this.x,this.y,12,0,Math.PI*2); ctx.fill();
+      ctx.fillStyle=(this.side==="player")?"white":"black";
+      ctx.font="14px sans-serif"; ctx.textAlign="center"; ctx.textBaseline="middle";
+      ctx.fillText(this.label,this.x,this.y);
+    }
   }
 
   update(){


### PR DESCRIPTION
## Summary
- Draw the dragon across the three central lanes with a wide rectangle
- Treat dragon as occupying three lanes for melee and range calculations

## Testing
- `node --check game.js`
- `node --check units.js`


------
https://chatgpt.com/codex/tasks/task_e_68bde8f133808333883c0693e1cc2a4f