### PR TITLE
Fix combat hit detection for three-lane layout

### DIFF
--- a/game.js
+++ b/game.js
@@ -18,6 +18,9 @@ let pendingUnitType = null;
 let pendingSpecial = null;
 let enemySpawnTimer = null;
 
+// レーン数
+const LANES = 3;
+
 // 近接判定
 function inMeleeRange(a,b){
   const laneDiff = Math.abs(a.lane-b.lane);
@@ -34,13 +37,13 @@ function inMeleeRange(a,b){
 // 射程判定
 function inUnitRange(a,b){
   let laneDiff = a.lane-b.lane;
-  let dx = laneDiff*(canvas.width/5);
+  let dx = laneDiff*(canvas.width/LANES);
   const dy = (a.y-b.y);
   if(a.role==="dragon" || b.role==="dragon"){
     if(Math.abs(laneDiff)<=1){
       dx = 0;
     }else{
-      dx = (Math.abs(laneDiff)-1)*(canvas.width/5)*Math.sign(laneDiff);
+      dx = (Math.abs(laneDiff)-1)*(canvas.width/LANES)*Math.sign(laneDiff);
     }
   }
   return Math.hypot(dx,dy) <= a.range;
@@ -126,7 +129,7 @@ function startGame(){
     if(!pendingUnitType) return;
     const cost = unitCosts[pendingUnitType];
     if(playerGold < cost) return;
-    const lane = Math.floor(x/(canvas.width/5));
+    const lane = Math.floor(x/(canvas.width/LANES));
     playerUnits.push(new Unit(pendingUnitType,"player",lane,canvas.height-40));
     playerGold -= cost;
     updateGoldUI();
@@ -147,7 +150,7 @@ function spawnEnemy(){
   // 通常モード
   const types=["goblin","orc","golem","shaman","phantom"];
   const type=types[Math.floor(Math.random()*types.length)];
-  const lane=Math.floor(Math.random()*5);
+  const lane=Math.floor(Math.random()*LANES);
   enemyUnits.push(new Unit(type,"enemy",lane,40));
 }
 
@@ -182,8 +185,8 @@ function updateGoldUI(){
 function loop(){
   ctx.clearRect(0,0,canvas.width,canvas.height);
   ctx.strokeStyle="#555";
-  for(let i=1;i<5;i++){ 
-    ctx.beginPath(); ctx.moveTo(i*canvas.width/5,0); ctx.lineTo(i*canvas.width/5,canvas.height); ctx.stroke(); 
+  for(let i=1;i<LANES;i++){
+    ctx.beginPath(); ctx.moveTo(i*canvas.width/LANES,0); ctx.lineTo(i*canvas.width/LANES,canvas.height); ctx.stroke();
   }
   ctx.fillStyle="white";
   ctx.fillText(`自陣HP:${playerBaseHP}`,10,15);

--- a/units.js
+++ b/units.js
@@ -22,7 +22,8 @@ let unitStats = {
 class Unit {
   constructor(type, side, lane, y){
     this.type=type; this.side=side; this.lane=lane;
-    this.x = lane*(canvas.width/5) + (canvas.width/10);
+    const laneWidth = canvas.width / LANES;
+    this.x = lane*laneWidth + laneWidth/2;
     this.y = y;
     const st = unitStats[type];
     this.hp=st.hp; this.atk=st.atk;
@@ -53,7 +54,7 @@ class Unit {
 
   draw(){
     if(this.role==="dragon"){
-      const width = canvas.width * 3/5;
+      const width = canvas.width * (3/LANES);
       const height = 60;
       ctx.fillStyle=this.color;
       ctx.fillRect(this.x - width/2, this.y - height/2, width, height);


### PR DESCRIPTION
## Summary
- add global lane count constant and update range and placement math
- compute unit positions and dragon width using new lane width

## Testing
- `node --check game.js && node --check units.js`


------
https://chatgpt.com/codex/tasks/task_e_68bdee8cbb888333bb31b1ae9adc9fbd