### PR TITLE
Restore five-lane battlefield

### DIFF
--- a/game.js
+++ b/game.js
@@ -19,7 +19,7 @@ let pendingSpecial = null;
 let enemySpawnTimer = null;
 
 // レーン数
-const LANES = 3;
+const LANES = 5;
 
 // 近接判定
 function inMeleeRange(a,b){


### PR DESCRIPTION
## Summary
- Reset game field to five lanes by setting `LANES` constant back to 5

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68be187bcb848333a2dedf6dcf6c22ea