### PR TITLE
Fix game freeze due to phantom attack error

### DIFF
--- a/game.js
+++ b/game.js
@@ -252,9 +252,7 @@ function loop(){
       if(e.role==="phantom" && e.cooldown<=0 && playerUnits.length>0){
         const t=playerUnits[Math.floor(Math.random()*playerUnits.length)];
         if(inUnitRange(e,t)){
-         codex/add-square-shape-drawing-to-projectile
           projectiles.push(new Projectile(e.x,e.y+12,t,e.atk,"white"));
-         main
           e.cooldown=100;  // ★ 50 → 100
         }
       }


### PR DESCRIPTION
## Summary
- remove stray tokens causing runtime error during phantom attacks
- ensure game loop runs by preventing ReferenceErrors

## Testing
- `node --check game.js`
- `node --check units.js`
- `node --check projectiles.js`
- `node --check ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68bed2a74224833381f101ffd6b1e262