### PR TITLE
Show damage and healing numbers

### DIFF
--- a/game.js
+++ b/game.js
@@ -13,7 +13,7 @@ document.querySelectorAll('.special-btn').forEach(btn => {
   btn.addEventListener('mouseup', () => btn.classList.remove('pressed'));
   btn.addEventListener('mouseleave', () => btn.classList.remove('pressed'));
 });
-let playerBaseHP, enemyBaseHP, playerUnits, enemyUnits, projectiles, hitMarks, swingMarks, specialEffects;
+let playerBaseHP, enemyBaseHP, playerUnits, enemyUnits, projectiles, hitMarks, swingMarks, specialEffects, floatingTexts;
 let pendingUnitType = null;
 let pendingSpecial = null;
 let enemySpawnTimer = null;
@@ -108,7 +108,7 @@ function startGame(){
   if(sb) sb.textContent = `x${gameSpeed}`;
 
   playerBaseHP=100; enemyBaseHP=100;
-  playerUnits=[]; enemyUnits=[]; projectiles=[]; hitMarks=[]; swingMarks=[]; specialEffects=[];
+  playerUnits=[]; enemyUnits=[]; projectiles=[]; hitMarks=[]; swingMarks=[]; specialEffects=[]; floatingTexts=[];
   pendingSpecial = null;
   playerGold = 500;
   updateGoldUI();
@@ -199,18 +199,20 @@ function loop(){
     for(const e of enemyUnits){
       if(inMeleeRange(p,e)){
         p.target=e; e.target=p;
-        if(p.cooldown<=0){ 
+        if(p.cooldown<=0){
           let dmg = (p.meleeAtk !== undefined) ? p.meleeAtk : p.atk;
           e.hp -= dmg;
-          hitMarks.push(new HitMark(e.x,e.y)); 
-          swingMarks.push(new SwingMark(p.x,p.y,"player")); 
+          hitMarks.push(new HitMark(e.x,e.y));
+          floatingTexts.push(new FloatingText(e.x, e.y-10, `-${dmg}`));
+          swingMarks.push(new SwingMark(p.x,p.y,"player"));
           p.cooldown=60;   // ★ 30 → 60
         }
-        if(e.cooldown<=0){ 
+        if(e.cooldown<=0){
           let dmg = (e.meleeAtk !== undefined) ? e.meleeAtk : e.atk;
           p.hp -= dmg;
-          hitMarks.push(new HitMark(p.x,p.y)); 
-          swingMarks.push(new SwingMark(e.x,e.y,"enemy")); 
+          hitMarks.push(new HitMark(p.x,p.y));
+          floatingTexts.push(new FloatingText(p.x, p.y-10, `-${dmg}`));
+          swingMarks.push(new SwingMark(e.x,e.y,"enemy"));
           e.cooldown=80;   // ★ 40 → 80
         }
       }else{
@@ -281,6 +283,8 @@ function loop(){
   hitMarks = hitMarks.filter(h=>h.life>0);
   for(const s of swingMarks){ s.update(); s.draw(); }
   swingMarks = swingMarks.filter(s=>s.life>0);
+  for(const t of floatingTexts){ t.update(); t.draw(); }
+  floatingTexts = floatingTexts.filter(t=>t.life>0);
   for(const fx of specialEffects){ fx.update(); fx.draw(); }
   specialEffects = specialEffects.filter(fx=>fx.active);
 
@@ -294,8 +298,22 @@ function loop(){
     }
     return e.y<canvas.height;
   });
-  for(const e of enemyUnits){ if(e.y>=canvas.height-30){ playerBaseHP-=e.atk; e.hp=0; } }
-  for(const p of playerUnits){ if(p.y<=30){ enemyBaseHP-=p.atk; playerGold += 150; updateGoldUI(); p.hp=0; } }
+  for(const e of enemyUnits){
+    if(e.y>=canvas.height-30){
+      playerBaseHP-=e.atk;
+      floatingTexts.push(new FloatingText(e.x, canvas.height-40, `-${e.atk}`));
+      e.hp=0;
+    }
+  }
+  for(const p of playerUnits){
+    if(p.y<=30){
+      enemyBaseHP-=p.atk;
+      floatingTexts.push(new FloatingText(p.x,40, `-${p.atk}`));
+      playerGold += 150;
+      updateGoldUI();
+      p.hp=0;
+    }
+  }
   enemyUnits = enemyUnits.filter(e=>e.hp>0 && e.y<canvas.height);
   playerUnits = playerUnits.filter(u=>u.hp>0 && u.y>0);
 
@@ -365,7 +383,10 @@ function triggerSpecial(type,x,y){
 
   if(type === "meteor"){
     for(const e of enemyUnits){
-      if(Math.hypot(e.x - x, e.y - y) <= radius){ e.hp -= 200; }
+      if(Math.hypot(e.x - x, e.y - y) <= radius){
+        e.hp -= 200;
+        floatingTexts.push(new FloatingText(e.x, e.y-10, `-200`));
+      }
     }
     mana.meteor = 0;
     specialEffects.push(new SpecialCircle(x,y,"red"));
@@ -375,7 +396,10 @@ function triggerSpecial(type,x,y){
 
   if(type === "heal"){
     for(const p of playerUnits){
-      if(Math.hypot(p.x - x, p.y - y) <= radius){ p.hp += 100; }
+      if(Math.hypot(p.x - x, p.y - y) <= radius){
+        p.hp += 100;
+        floatingTexts.push(new FloatingText(p.x, p.y-10, `+100`, "green"));
+      }
     }
     mana.heal = 0;
     specialEffects.push(new SpecialCircle(x,y,"green"));

--- a/projectiles.js
+++ b/projectiles.js
@@ -18,7 +18,12 @@ class Projectile{
     const dx=this.target.x-this.x, dy=this.target.y-this.y;
     const d=Math.hypot(dx,dy);
     this.angle=Math.atan2(dy,dx);
-    if(d<5){ this.target.hp-=this.atk; hitMarks.push(new HitMark(this.target.x,this.target.y)); this.active=false; }
+    if(d<5){
+      this.target.hp -= this.atk;
+      hitMarks.push(new HitMark(this.target.x,this.target.y));
+      floatingTexts.push(new FloatingText(this.target.x, this.target.y-10, `-${this.atk}`));
+      this.active=false;
+    }
     else { this.x += (dx/d)*this.speed*gameSpeed; this.y += (dy/d)*this.speed*gameSpeed; }
   }
 
@@ -58,7 +63,12 @@ class HealProjectile{
     if(!this.target || this.target.hp<=0){ this.active=false; return; }
     const dx=this.target.x-this.x, dy=this.target.y-this.y;
     const d=Math.hypot(dx,dy);
-    if(d<5){ this.target.hp += this.amount; hitMarks.push(new HealMark(this.target.x,this.target.y)); this.active=false; }
+    if(d<5){
+      this.target.hp += this.amount;
+      hitMarks.push(new HealMark(this.target.x,this.target.y));
+      floatingTexts.push(new FloatingText(this.target.x, this.target.y-10, `+${this.amount}`, "green"));
+      this.active=false;
+    }
     else { this.x += (dx/d)*this.speed*gameSpeed; this.y += (dy/d)*this.speed*gameSpeed; }
   }
   draw(){
@@ -123,6 +133,25 @@ class SpecialText{
     ctx.textAlign="center";
     ctx.globalAlpha = this.life/60;
     ctx.fillText(this.text, canvas.width/2, canvas.height/2);
+    ctx.restore();
+  }
+}
+
+class FloatingText{
+  constructor(x,y,text,color="white"){
+    this.x=x; this.y=y; this.text=text; this.color=color; this.life=30;
+  }
+  update(){
+    this.y -= 0.5*gameSpeed;
+    this.life -= gameSpeed;
+  }
+  draw(){
+    ctx.save();
+    ctx.fillStyle=this.color;
+    ctx.font="16px sans-serif";
+    ctx.textAlign="center";
+    ctx.globalAlpha = this.life/30;
+    ctx.fillText(this.text,this.x,this.y);
     ctx.restore();
   }
 }


### PR DESCRIPTION
## Summary
- Display floating damage numbers in white and healing numbers in green
- Add FloatingText class and integrate with melee, projectiles, specials, and base hits

## Testing
- `node --check game.js`
- `node --check projectiles.js`
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68bedffa58788333970a53aeee7c8e4e