### PR TITLE
feat: synchronize title with version

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Chrono Bulward v0.2.27 (modular)</title>
+<title>Chrono Bulward v0.2.28 (modular)</title>
 <style>
   body { margin:0; background:#222; color:#eee; font-family:monospace; text-align:center; }
   #gameCanvas { background:#333; display:none; margin:0 auto; border:2px solid #000; }
@@ -86,7 +86,8 @@
 </style>
 </head>
 <body>
-<h1 id="title">Chrono Bulward v0.2.27 (modular)
+<h1 id="title">
+  <span id="titleText">Chrono Bulward</span>
   <button id="historyBtn" onclick="showChangelog()" style="margin-left:10px;">変更履歴</button>
 </h1>
 
@@ -135,6 +136,7 @@
 <div id="changelog">
   <h2>変更履歴</h2>
   <ul>
+    <li>v0.2.28 タイトルとバージョンを同期。</li>
     <li>v0.2.27 モジュール化された構成。</li>
     <li>v0.2.26 UIやバランスの調整。</li>
   </ul>

--- a/ui.js
+++ b/ui.js
@@ -1,3 +1,10 @@
+// ---- バージョン管理 ----
+const VERSION = "0.2.28";
+const FULL_TITLE = `Chrono Bulward v${VERSION} (modular)`;
+document.title = FULL_TITLE;
+const titleEl = document.getElementById("titleText");
+if (titleEl) titleEl.textContent = FULL_TITLE;
+
 // ---- スライダー設定範囲 ----
 const unitConfig = {
   swordsman:{name:"ナイト", props:{hp:[50,300], atk:[5,30], speed:[0.1,1,0.05], range:[10,100]}},


### PR DESCRIPTION
## Summary
- centralize version as 0.2.28 and apply to page title and header
- record v0.2.28 in the changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bee0edcc1c8333b0f1ce5c330b9098