### PR TITLE
fix: adjust mobile canvas height and bump version to v0.2.30

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Chrono Bulward v0.2.29 (modular)</title>
+<title>Chrono Bulward v0.2.30 (modular)</title>
 <style>
   body { margin:0; background:#222; color:#eee; font-family:monospace; text-align:center; }
   #gameCanvas { background:#333; display:none; margin:0 auto; border:2px solid #000; }
@@ -90,7 +90,7 @@
     #gameCanvas {
       width: 100%;
       height: auto;
-      max-height: calc(100vh - 220px); /* UI 分の高さを差し引いて表示領域に収める */
+      max-height: calc(100dvh - 300px); /* UI 分の高さを差し引いて表示領域に収める */
     }
   }
 </style>
@@ -146,6 +146,7 @@
 <div id="changelog">
   <h2>変更履歴</h2>
   <ul>
+    <li>v0.2.30 スマホ表示で画面下部が見切れる問題を修正。</li>
     <li>v0.2.29 クレリックが回復射程内でも移動を継続。</li>
     <li>v0.2.28 タイトルとバージョンを同期。</li>
     <li>v0.2.27 モジュール化された構成。</li>

--- a/ui.js
+++ b/ui.js
@@ -1,5 +1,5 @@
 // ---- バージョン管理 ----
-const VERSION = "0.2.29";
+const VERSION = "0.2.30";
 const FULL_TITLE = `Chrono Bulward v${VERSION} (modular)`;
 document.title = FULL_TITLE;
 const titleEl = document.getElementById("titleText");


### PR DESCRIPTION
## Summary
- prevent mobile UI from being cut off by adjusting canvas max height
- bump version to v0.2.30 and update changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68beee34c1508333b9525e5346c57370