### PR TITLE
Adjust damage text size to midpoint

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Chrono Bulward v0.2.32 (modular)</title>
+<title>Chrono Bulward v0.2.33 (modular)</title>
 <style>
   body { margin:0; background:#222; color:#eee; font-family:monospace; text-align:center; }
   #gameCanvas { background:#333; display:none; margin:0 auto; border:2px solid #000; }
@@ -146,6 +146,7 @@
 <div id="changelog">
   <h2>変更履歴</h2>
     <ul>
+      <li>v0.2.33 ダメージと回復表示の文字サイズを調整。</li>
       <li>v0.2.32 ユニットと戦闘エフェクトの表示を拡大。</li>
       <li>v0.2.31 遠隔攻撃ユニットの挙動を調整。</li>
       <li>v0.2.30 スマホ表示で画面下部が見切れる問題を修正。</li>

--- a/projectiles.js
+++ b/projectiles.js
@@ -163,7 +163,7 @@ class FloatingText{
   draw(){
     ctx.save();
     ctx.fillStyle=this.color;
-    ctx.font="32px sans-serif";
+    ctx.font="24px sans-serif";
     ctx.textAlign="center";
     ctx.globalAlpha = this.life/30;
     ctx.fillText(this.text,this.x,this.y);

--- a/ui.js
+++ b/ui.js
@@ -1,5 +1,5 @@
 // ---- バージョン管理 ----
-const VERSION = "0.2.32";
+const VERSION = "0.2.33";
 const FULL_TITLE = `Chrono Bulward v${VERSION} (modular)`;
 document.title = FULL_TITLE;
 const titleEl = document.getElementById("titleText");


### PR DESCRIPTION
## Summary
- shrink floating combat text to 24px for balanced readability
- bump version to v0.2.33 and log change

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa966182883338d36ed14e8bd7d73