### PR TITLE
Adjust unit radius and HP bar offset

### DIFF
--- a/units.js
+++ b/units.js
@@ -72,11 +72,11 @@ class Unit {
       hpBarY = this.y - height/2 - 15;
     }else{
       ctx.fillStyle=this.color;
-      ctx.beginPath(); ctx.arc(this.x,this.y,18,0,Math.PI*2); ctx.fill();
+      ctx.beginPath(); ctx.arc(this.x,this.y,14,0,Math.PI*2); ctx.fill();
       ctx.fillStyle=(this.side==="player")?"white":"black";
       ctx.font="21px sans-serif"; ctx.textAlign="center"; ctx.textBaseline="middle";
       ctx.fillText(this.label,this.x,this.y);
-      hpBarY = this.y - 30;
+      hpBarY = this.y - 26;
     }
 
     // ライフゲージ（左寄せ・最大HP比例）


### PR DESCRIPTION
## Summary
- Reduce non-dragon unit draw radius from 18 to 14
- Shift HP bar 4px closer to non-dragon units to keep 12px separation

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb9aa52dc83338e46bf461a66dde4