### PR TITLE
Adjust dragon size to span three lanes

### DIFF
--- a/units.js
+++ b/units.js
@@ -62,7 +62,7 @@ class Unit {
     let hpBarY;
 
     if(this.role==="dragon"){
-      const width = Math.min(canvas.width, canvas.width * (4.5/LANES));
+      const width = Math.min(canvas.width, canvas.width * (3/LANES));
       const height = 90;
       ctx.fillStyle=this.color;
       ctx.fillRect(this.x - width/2, this.y - height/2, width, height);


### PR DESCRIPTION
## Summary
- Reduce dragon drawing width from 4.5 lanes to 3 lanes so it no longer overwhelms the playfield

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcc57508c8333bd5198a2ee31564a