### PR TITLE
chore: bump version to 0.2.34

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Chrono Bulward v0.2.33 (modular)</title>
+<title>Chrono Bulward v0.2.34 (modular)</title>
 <style>
   body { margin:0; background:#222; color:#eee; font-family:monospace; text-align:center; }
   #gameCanvas { background:#333; display:none; margin:0 auto; border:2px solid #000; }
@@ -97,7 +97,7 @@
 </head>
 <body>
 <h1 id="title">
-  <span id="titleText">Chrono Bulward</span>
+  <span id="titleText">Chrono Bulward v0.2.34 (modular)</span>
   <button id="historyBtn" onclick="showChangelog()" style="margin-left:10px;">変更履歴</button>
 </h1>
 
@@ -146,6 +146,7 @@
 <div id="changelog">
   <h2>変更履歴</h2>
     <ul>
+      <li>v0.2.34 マナとUIの微調整。</li>
       <li>v0.2.33 ダメージと回復表示の文字サイズを調整。</li>
       <li>v0.2.32 ユニットと戦闘エフェクトの表示を拡大。</li>
       <li>v0.2.31 遠隔攻撃ユニットの挙動を調整。</li>

--- a/ui.js
+++ b/ui.js
@@ -1,5 +1,5 @@
 // ---- バージョン管理 ----
-const VERSION = "0.2.33";
+const VERSION = "0.2.34";
 const FULL_TITLE = `Chrono Bulward v${VERSION} (modular)`;
 document.title = FULL_TITLE;
 const titleEl = document.getElementById("titleText");


### PR DESCRIPTION
## Summary
- bump app version to 0.2.34 and display it in the header and document title
- document mana and UI tweaks in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c005dd520c8333b9f0667a7a9a9ffa