### PR TITLE
fix: display first mana charge color

### DIFF
--- a/game.js
+++ b/game.js
@@ -172,12 +172,15 @@ function updateManaUI(type){
   if(manaCharges[type] === 0){
     bar1.value = mana[type];
     bar2.value = 0;
+    bar2.style.display = "none";
   } else if(manaCharges[type] === 1){
     bar1.value = maxMana[type];
     bar2.value = mana[type];
+    bar2.style.display = "block";
   } else {
     bar1.value = maxMana[type];
     bar2.value = maxMana[type];
+    bar2.style.display = "block";
   }
 
   bar1.classList.toggle("mana-full", manaCharges[type] >= 1);

--- a/index.html
+++ b/index.html
@@ -88,6 +88,16 @@
   #healBar1::-webkit-progress-value, #healBar2::-webkit-progress-value { background: green; }
   #healBar1::-moz-progress-bar, #healBar2::-moz-progress-bar { background: green; }
 
+  /* 2段目の未充填部分が1段目の色を隠さないように透過 */
+  #freezeBar2, #meteorBar2, #healBar2 {
+    background: transparent;
+  }
+  #freezeBar2::-webkit-progress-bar,
+  #meteorBar2::-webkit-progress-bar,
+  #healBar2::-webkit-progress-bar {
+    background: transparent;
+  }
+
   .mana-bars {
     position: relative;
     display: inline-block;


### PR DESCRIPTION
## Summary
- avoid overlay progress bar from hiding the first mana bar color
- toggle second mana bar visibility based on charge level

## Testing
- `node --check game.js`
- `node --check ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68c00cfabe3483339566fdc6f12dd2a0