### PR TITLE
Expand special attack area during second mana charge

### DIFF
--- a/game.js
+++ b/game.js
@@ -406,47 +406,14 @@ function triggerSpecial(type,x,y){
     }
   }
   const multiplier = 1 + progress; // 2周目はゲージ割合に応じて最大2倍まで上昇
-  const radius = 140 * multiplier;
+  const baseRadius = 140;
+  const radius = baseRadius * multiplier;
+  const colors = { freeze:"gray", meteor:"red", heal:"green" };
+  const texts  = { freeze:"❄️ フリーズ！！", meteor:"☄️ メテオ！！", heal:"✨ ヒーリング！！" };
 
-  if(type === "freeze"){
-    const affected=[];
-    for(const e of enemyUnits){
-      if(Math.hypot(e.x - x, e.y - y) <= radius){
-        e.speedBackup = e.speed;
-        e.speed = 0;
-        affected.push(e);
-      }
-    }
-    setTimeout(()=>{
-      for(const e of affected){
-        if(e.speedBackup !== undefined){ e.speed = e.speedBackup; delete e.speedBackup; }
-      }
-    },5000 * multiplier);
-    specialEffects.push(new SpecialCircle(x,y,"gray",radius));
-    specialEffects.push(new SpecialText("❄️ フリーズ！！"));
-  }
-
-  if(type === "meteor"){
-    for(const e of enemyUnits){
-      if(Math.hypot(e.x - x, e.y - y) <= radius){
-        e.hp -= 200 * multiplier;
-        floatingTexts.push(new FloatingText(e.x, e.y-15, `-${200 * multiplier}`));
-      }
-    }
-    specialEffects.push(new SpecialCircle(x,y,"red",radius));
-    specialEffects.push(new SpecialText("☄️ メテオ！！"));
-  }
-
-  if(type === "heal"){
-    for(const p of playerUnits){
-      if(Math.hypot(p.x - x, p.y - y) <= radius){
-        p.hp += 100 * multiplier;
-        floatingTexts.push(new FloatingText(p.x, p.y-15, `+${100 * multiplier}`, "green"));
-      }
-    }
-    specialEffects.push(new SpecialCircle(x,y,"green",radius));
-    specialEffects.push(new SpecialText("✨ ヒーリング！！"));
-  }
+  specialEffects.push(new ExpandingEffectZone(x,y,type,baseRadius,radius,multiplier));
+  specialEffects.push(new SpecialCircle(x,y,colors[type],radius));
+  specialEffects.push(new SpecialText(texts[type]));
 
   mana[type] = 0;
   manaCharges[type] = 0;

--- a/projectiles.js
+++ b/projectiles.js
@@ -137,6 +137,52 @@ class SpecialCircle{
   }
 }
 
+class ExpandingEffectZone{
+  constructor(x,y,type,startRadius,endRadius,multiplier){
+    this.x=x; this.y=y; this.type=type;
+    this.radius=startRadius; this.endRadius=endRadius;
+    this.multiplier=multiplier; this.active = startRadius < endRadius;
+    this.affected=new Set();
+    this.apply();
+  }
+  apply(){
+    if(this.type==="freeze"){
+      const duration=5000*this.multiplier;
+      for(const e of enemyUnits){
+        if(!this.affected.has(e) && Math.hypot(e.x-this.x,e.y-this.y)<=this.radius){
+          e.speedBackup=e.speed; e.speed=0; this.affected.add(e);
+          setTimeout(()=>{
+            if(e.speedBackup!==undefined){ e.speed=e.speedBackup; delete e.speedBackup; }
+          },duration);
+        }
+      }
+    }else if(this.type==="meteor"){
+      for(const e of enemyUnits){
+        if(!this.affected.has(e) && Math.hypot(e.x-this.x,e.y-this.y)<=this.radius){
+          e.hp -= 200*this.multiplier;
+          floatingTexts.push(new FloatingText(e.x,e.y-15,`-${200*this.multiplier}`));
+          this.affected.add(e);
+        }
+      }
+    }else if(this.type==="heal"){
+      for(const p of playerUnits){
+        if(!this.affected.has(p) && Math.hypot(p.x-this.x,p.y-this.y)<=this.radius){
+          p.hp += 100*this.multiplier;
+          floatingTexts.push(new FloatingText(p.x,p.y-15,`+${100*this.multiplier}`,"green"));
+          this.affected.add(p);
+        }
+      }
+    }
+  }
+  update(){
+    if(!this.active) return;
+    this.radius = Math.min(this.radius + 8*gameSpeed, this.endRadius);
+    this.apply();
+    if(this.radius >= this.endRadius){ this.active=false; }
+  }
+  draw(){}
+}
+
 // 特殊攻撃の字幕表示
 class SpecialText{
   constructor(text){ this.text=text; this.life=60; this.active=true; }


### PR DESCRIPTION
## Summary
- Grow special attack radius from the base size to a larger area depending on second mana bar progress
- Introduce `ExpandingEffectZone` to apply freeze, meteor and heal effects to units as the radius enlarges

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c011f83ebc8333a079df01caed92d1