### PR TITLE
Adjust game speed multipliers to be 20% slower

### DIFF
--- a/game.js
+++ b/game.js
@@ -81,7 +81,7 @@ const enemyBounties = {
   dragon: 500
 };
 
-const speedLevels = [1,1.5,2];
+const speedLevels = [0.8,1.2,1.6];
 let speedIndex = 0;
 let gameSpeed = speedLevels[speedIndex];
 


### PR DESCRIPTION
## Summary
- Slow default game speeds by 20%

## Testing
- `node - <<'NODE'\n...\nNODE`

------
https://chatgpt.com/codex/tasks/task_e_68c02a10eb688333ad82f30d8ece0050